### PR TITLE
Add missing truncate() call on BytesIO object

### DIFF
--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -199,6 +199,7 @@ class MocketSocket(object):
 
         self.fd.seek(0)
         self.fd.write(response)
+        self.fd.truncate()
         self.fd.seek(0)
 
     def recv(self, buffersize, flags=None):

--- a/tests/main/test_mocket.py
+++ b/tests/main/test_mocket.py
@@ -76,7 +76,7 @@ class MocketTestCase(TestCase):
         self.assertEqual(entry.get_response(), encode_to_bytes(''))
         
     @mocketize
-    def test_foo(self):
+    def test_subsequent_recv_requests_have_correct_length(self):
         Mocket.register(
             MocketEntry(
                 ('localhost', 80),

--- a/tests/main/test_mocket.py
+++ b/tests/main/test_mocket.py
@@ -74,6 +74,25 @@ class MocketTestCase(TestCase):
     def test_empty_getresponse(self):
         entry = MocketEntry(('localhost', 8080), [])
         self.assertEqual(entry.get_response(), encode_to_bytes(''))
+        
+    @mocketize
+    def test_foo(self):
+        Mocket.register(
+            MocketEntry(
+                ('localhost', 80),
+                [
+                    b'Long payload',
+                    b'Short'
+                ]
+            )
+        )
+        _so = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        _so.connect(('localhost', 80))
+        _so.sendall(b'first\r\n')
+        assert _so.recv(4096) == b'Long payload'
+        _so.sendall(b'second\r\n')
+        assert _so.recv(4096) == b'Short'
+        _so.close()
 
 
 class MocketizeTestCase(TestCase):


### PR DESCRIPTION
When subsequent payload to be pushed by mocket was shorter than previous one, additional data were dumped. This was because BytesIO object had longer length; calling truncate() on the BytesIO object solves this problem

code to reproduce the problem, before this patch:

```
@mocketize
def test_something():
    Mocket.register(
        MocketEntry(
            ('example.com', 80),
            [
                b'this is some long payload'
                b'short',
            ]
        ),
    )
```
then, when one would use socket object, and call `recv` on it, one would get part of the first payload with the second call