### PR TITLE
Test to demonstrate BadStatusLine

### DIFF
--- a/tests/main/test_https.py
+++ b/tests/main/test_https.py
@@ -8,7 +8,7 @@ import pytest
 
 from mocket import mocketize, Mocket
 from mocket.mockhttp import Entry
-from tests import urlopen
+from tests import urlopen, HTTPError
 
 
 @pytest.fixture
@@ -57,3 +57,10 @@ def test_truesendall_with_recording_https():
         responses = json.load(f)
 
     assert len(responses['httpbin.org']['443'].keys()) == 1
+
+
+@mocketize
+def test_sendall_forgot_to_ignore_querystring():
+    Entry.single_register(Entry.GET, 'https://graph.facebook.com/')
+    with pytest.raises(HTTPError):
+        urlopen('https://graph.facebook.com/?query=string')


### PR DESCRIPTION
This isn't a problem in mocket.

When the match fails (e.g. when I forget to set `match_querystring` to False), the request is just sent over the wire like normal.  

In my case, I am testing against https://graph.facebook.com which apparently has some sort of malformed response that is breaking down.

It is an interesting error, but please feel free to close this.
