### PR TITLE
Avoid libmagic importerror

### DIFF
--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -7,4 +7,4 @@ except ImportError:
 
 __all__ = (mocketize, Mocket, MocketEntry, Mocketizer)
 
-__version__ = '2.4.1'
+__version__ = '2.5.0'

--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -3,7 +3,10 @@ import re
 import time
 from io import BytesIO
 
-import magic
+try:
+    import magic
+except ImportError:
+    magic = None
 
 from .compat import (
     BaseHTTPRequestHandler,
@@ -41,7 +44,10 @@ class Response(object):
     headers = None
     is_file_object = False
 
-    def __init__(self, body='', status=200, headers=None):
+    def __init__(self, body='', status=200, headers=None, lib_magic=magic):
+        # needed for testing libmagic import failure
+        self.magic = lib_magic
+
         headers = headers or {}
         try:
             #  File Objects
@@ -73,7 +79,7 @@ class Response(object):
         }
         if not self.is_file_object:
             self.headers['Content-Type'] = 'text/plain; charset=utf-8'
-        else:
+        elif self.magic:
             self.headers['Content-Type'] = decode_from_bytes(magic.from_buffer(self.body, mime=True))
 
     def set_extra_headers(self, headers):

--- a/tests/main/test_http.py
+++ b/tests/main/test_http.py
@@ -242,6 +242,22 @@ class HttpEntryTestCase(HttpTestCase):
         self.assertEqual(r.headers['Content-Type'], 'image/png')
 
     @mocketize
+    def test_file_object_with_no_lib_magic(self):
+        url = 'http://github.com/fluidicon.png'
+        filename = 'tests/fluidicon.png'
+        file_obj = open(filename, 'rb')
+        Entry.register(Entry.GET, url, Response(body=file_obj, lib_magic=None))
+        r = requests.get(url)
+        remote_content = r.content
+        local_file_obj = open(filename, 'rb')
+        local_content = local_file_obj.read()
+        self.assertEqual(remote_content, local_content)
+        self.assertEqual(len(remote_content), len(local_content))
+        self.assertEqual(int(r.headers['Content-Length']), len(local_content))
+        with self.assertRaises(KeyError):
+            self.assertEqual(r.headers['Content-Type'], 'image/png')
+
+    @mocketize
     def test_same_url_different_methods(self):
         url = 'http://bit.ly/fakeurl'
         response_to_mock = {


### PR DESCRIPTION
`Mocket` won't fail if `magic` cannot be imported, as requested by #81.