### PR TITLE
fixes non ascii characters in README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url='https://github.com/mindflayer/python-mocket',
     description='Socket Mock Framework - for all kinds of socket animals, web-clients included - \
         with gevent/asyncio/SSL support',
-    long_description=io.open('README.rst').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     packages=find_packages(exclude=exclude_packages),
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
I wasn't able to install due to unicode characters in readme

Error:
```
Collecting mocket==2.7.2 (from -r requirements.txt (line 44))
  Downloading https://files.pythonhosted.org/packages/a5/c9/478da224865ede99a69cee4bcd7593185d8a92e5aa6f044e86445cfe7ab8/mocket-2.7.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-a52nwr9c/mocket/setup.py", line 37, in <module>
        long_description=io.open('README.rst').read(),
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc9 in position 25: ordinal not in range(128)
```