### PR TITLE
Add tests to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 include README.rst LICENSE *.txt
+recursive-include tests *.json
+recursive-include tests *.png
+recursive-include tests *.py
+recursive-include tests *.txt

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = io.open(os.path.join(os.path.dirname(__file__), 'requirements
 tests_requires = io.open(os.path.join(os.path.dirname(__file__), 'test_requirements.txt')).readlines()
 
 pook_requires = ('pook>=0.2.1', )
-exclude_packages = ('tests', )
+exclude_packages = ('tests', 'tests.*')
 
 
 def read_version(package):


### PR DESCRIPTION
Exclude tests.* from the wheel, but include tests/ in the sdist

Fixes https://github.com/mindflayer/python-mocket/issues/100