### PR TITLE
Fix for removing DeprecationWarning

### DIFF
--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -7,4 +7,4 @@ except ImportError:
 
 __all__ = ("mocketize", "Mocket", "MocketEntry", "Mocketizer")
 
-__version__ = "3.8.1"
+__version__ = "3.8.2"

--- a/mocket/compat.py
+++ b/mocket/compat.py
@@ -14,6 +14,7 @@ basestring = six.string_types
 
 PY2 = sys.version_info[0] == 2
 if PY2:
+    import collections as collections_abc
     from BaseHTTPServer import BaseHTTPRequestHandler
     from urlparse import urlsplit, parse_qs, unquote
 
@@ -29,6 +30,7 @@ if PY2:
     FileNotFoundError = IOError
     BlockingIOError = sock_error
 else:
+    import collections.abc as collections_abc
     from http.server import BaseHTTPRequestHandler
     from urllib.parse import urlsplit, parse_qs, unquote as unquote_utf8
 

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -23,6 +23,7 @@ from .compat import (
     JSONDecodeError,
     basestring,
     byte_type,
+    collections_abc,
     decode_from_bytes,
     encode_to_bytes,
     text_type,
@@ -543,7 +544,7 @@ class MocketEntry(object):
         self.location = location
         self.response_index = 0
 
-        if not isinstance(responses, collections.Iterable) or isinstance(
+        if not isinstance(responses, collections_abc.Iterable) or isinstance(
             responses, basestring
         ):
             responses = [responses]


### PR DESCRIPTION
Fix for removing `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc'`.