### PR TITLE
Add support for file's builtin magic module

### DIFF
--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -87,9 +87,16 @@ class Response(object):
         if not self.is_file_object:
             self.headers["Content-Type"] = "text/plain; charset=utf-8"
         elif self.magic:
-            self.headers["Content-Type"] = decode_from_bytes(
-                magic.from_buffer(self.body, mime=True)
-            )
+            if hasattr(self.magic, "from_buffer"):
+                # PyPI python-magic
+                self.headers["Content-Type"] = decode_from_bytes(
+                    magic.from_buffer(self.body, mime=True)
+                )
+            else:
+                # file's builtin python wrapper
+                _magic = magic.open(magic.MAGIC_MIME_TYPE)
+                _magic.load()
+                self.headers["Content-Type"] = _magic.buffer(self.body)
 
     def set_extra_headers(self, headers):
         for k, v in headers.items():


### PR DESCRIPTION
file's builtin magic module has a somewhat different API, and it's not
co-installable with pypi:python-magic as both has the same name. Adding
a fallback logic here makes mocket work with either one.

All related tests are passing here.