### PR TITLE
Remove pipenv from `setup_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=find_packages(exclude=exclude_packages),
     install_requires=install_requires,
-    setup_requires=["pipenv"],
+    setup_requires=[],
     extras_require={
         "speedups": [
             'xxhash;platform_python_implementation=="CPython"',


### PR DESCRIPTION
pipenv should not be required for sdist installations.

noticed this behavior when reviewing https://github.com/NixOS/nixpkgs/pull/95689