### PR TITLE
Fix for managing multiple `sendall()` correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 install-dev-requirements:
-	pip install pipenv==2020.6.2
+	pip install pipenv==2020.8.13
 
 install-test-requirements:
 	pipenv lock -r > requirements.txt

--- a/Pipfile
+++ b/Pipfile
@@ -8,9 +8,9 @@ python-magic = "*"
 six = "*"
 decorator = "*"
 urllib3 = "*"
+http-parser = "*"
 
 [dev-packages]
-pip = "==20.1.1"
 pre-commit = "*"
 pep8 = "*"
 pytest = ">4.6"

--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -7,4 +7,4 @@ except ImportError:
 
 __all__ = ("mocketize", "Mocket", "MocketEntry", "Mocketizer")
 
-__version__ = "3.8.7"
+__version__ = "3.9.0"

--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -14,7 +14,10 @@ from .compat import (
 )
 from .mocket import Mocket, MocketEntry
 
-from http_parser.parser import HttpParser
+try:
+    from http_parser.parser import HttpParser
+except ImportError:
+    from http_parser.pyparser import HttpParser
 
 try:
     import magic

--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -37,7 +37,9 @@ class Request:
         self.path = self.parser.get_path()
         self.headers = self.parser.get_headers()
         self.body = decode_from_bytes(self.parser.recv_body())
-        self.querystring = parse_qs(unquote_utf8(self.parser.get_query_string()), keep_blank_values=True)
+        self.querystring = parse_qs(
+            unquote_utf8(self.parser.get_query_string()), keep_blank_values=True
+        )
         if self.querystring:
             self.path += "?{}".format(self.parser.get_query_string())
 

--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import re
 import time
-from io import BytesIO
 
 from .compat import (
     BaseHTTPRequestHandler,
@@ -15,6 +14,8 @@ from .compat import (
 )
 from .mocket import Mocket, MocketEntry
 
+from http_parser.parser import HttpParser
+
 try:
     import magic
 except ImportError:
@@ -25,17 +26,20 @@ STATUS = dict([(k, v[0]) for k, v in BaseHTTPRequestHandler.responses.items()])
 CRLF = "\r\n"
 
 
-class Request(BaseHTTPRequestHandler):
+class Request:
+    parser = None
+
     def __init__(self, data):
-        _, self.body = decode_from_bytes(data).split("\r\n\r\n", 1)
-        self.rfile = BytesIO(encode_to_bytes(data))
-        self.raw_requestline = self.rfile.readline()
-        self.error_code = self.error_message = None
-        self.parse_request()
-        self.method = self.command
-        self.querystring = parse_qs(
-            unquote_utf8(urlsplit(self.path).query), keep_blank_values=True
-        )
+        self.parser = HttpParser()
+        self.parser.execute(data, len(data))
+
+        self.method = self.parser.get_method()
+        self.path = self.parser.get_path()
+        self.headers = self.parser.get_headers()
+        self.body = decode_from_bytes(self.parser.recv_body())
+        self.querystring = parse_qs(unquote_utf8(self.parser.get_query_string()), keep_blank_values=True)
+        if self.querystring:
+            self.path += "?{}".format(self.parser.get_query_string())
 
     def add_data(self, data):
         self.body += data
@@ -129,10 +133,12 @@ class Entry(MocketEntry):
         self._match_querystring = match_querystring
 
     def collect(self, data):
-        self._sent_data += data
         decoded_data = decode_from_bytes(data)
-        if not decoded_data.startswith(Entry.METHODS) and decoded_data.endswith(CRLF):
+        if not decoded_data.startswith(Entry.METHODS):
             Mocket.remove_last_request()
+            self._sent_data += data
+        else:
+            self._sent_data = data
         super(Entry, self).collect(self._sent_data)
 
     def can_handle(self, data):

--- a/tests/main/test_http.py
+++ b/tests/main/test_http.py
@@ -190,6 +190,14 @@ class HttpEntryTestCase(HttpTestCase):
         self.assertEqual(len(Mocket._requests), 3)
 
     @mocketize
+    def test_mockhttp_entry_collect_duplicates(self):
+        Entry.single_register(Entry.POST, "http://testme.org/", status=200, match_querystring=False)
+        requests.post("http://testme.org/?foo=bar", data="{'foo': 'bar'}", headers={'content-type': 'application/json'})
+        requests.post("http://testme.org/")
+        self.assertEqual(len(Mocket._requests), 2)
+        self.assertEqual(Mocket.last_request().path, "/")
+
+    @mocketize
     def test_multipart(self):
         url = "http://httpbin.org/post"
         data = '--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="content"\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 68\r\n\r\nAction: comment\nText: Comment with attach\nAttachment: x1.txt, x2.txt\r\n--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="attachment_2"; filename="x.txt"\r\nContent-Type: text/plain\r\nContent-Length: 4\r\n\r\nbye\n\r\n--xXXxXXyYYzzz\r\nContent-Disposition: form-data; name="attachment_1"; filename="x.txt"\r\nContent-Type: text/plain\r\nContent-Length: 4\r\n\r\nbye\n\r\n--xXXxXXyYYzzz--\r\n'

--- a/tests/main/test_http.py
+++ b/tests/main/test_http.py
@@ -191,8 +191,14 @@ class HttpEntryTestCase(HttpTestCase):
 
     @mocketize
     def test_mockhttp_entry_collect_duplicates(self):
-        Entry.single_register(Entry.POST, "http://testme.org/", status=200, match_querystring=False)
-        requests.post("http://testme.org/?foo=bar", data="{'foo': 'bar'}", headers={'content-type': 'application/json'})
+        Entry.single_register(
+            Entry.POST, "http://testme.org/", status=200, match_querystring=False
+        )
+        requests.post(
+            "http://testme.org/?foo=bar",
+            data="{'foo': 'bar'}",
+            headers={"content-type": "application/json"},
+        )
         requests.post("http://testme.org/")
         self.assertEqual(len(Mocket._requests), 2)
         self.assertEqual(Mocket.last_request().path, "/")


### PR DESCRIPTION
I also took the chance for replacing the HTTP parser and refactoring `Request`.
Fix for #123.