### PR TITLE
Minor fix for mocketoy example

### DIFF
--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -259,6 +259,7 @@ class MocketSocket(object):
         else:
             response = self.true_sendall(data, *args, **kwargs)
 
+        self.fd = MocketSocketCore()
         self.fd.seek(0)
         self.fd.write(response)
         self.fd.truncate()

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -243,6 +243,7 @@ class MocketSocket(object):
     def makefile(self, mode="r", bufsize=-1):
         self._mode = mode
         self._bufsize = bufsize
+        self.fd = MocketSocketCore()
         return self.fd
 
     def get_entry(self, data):
@@ -258,7 +259,6 @@ class MocketSocket(object):
         else:
             response = self.true_sendall(data, *args, **kwargs)
 
-        self.fd = MocketSocketCore()
         self.fd.seek(0)
         self.fd.write(response)
         self.fd.truncate()

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -243,7 +243,8 @@ class MocketSocket(object):
     def makefile(self, mode="r", bufsize=-1):
         self._mode = mode
         self._bufsize = bufsize
-        self.fd = MocketSocketCore()
+        if self.fd is None:
+            self.fd = MocketSocketCore()
         return self.fd
 
     def get_entry(self, data):

--- a/tests/main/test_mocket.py
+++ b/tests/main/test_mocket.py
@@ -115,12 +115,13 @@ class MocketTestCase(TestCase):
         assert buffer.read() == b"Long payloadShort"
 
     def test_makefile(self):
-        addr = ('localhost', 8080)
+        addr = ('localhost', 80)
         Mocket.register(MocketEntry(addr, ['Show me.\r\n']))
         with Mocketizer():
-            sock = socket.create_connection(addr)
-            fp = sock.makefile('rb')
-            sock.sendall(encode_to_bytes('...\r\n'))
+            _so = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _so.connect(addr)
+            fp = _so.makefile('rb')
+            _so.sendall(encode_to_bytes('...\r\n'))
             self.assertEqual(fp.read().strip(), encode_to_bytes('Show me.'))
             self.assertEqual(len(Mocket._requests), 1)
 

--- a/tests/main/test_mocket.py
+++ b/tests/main/test_mocket.py
@@ -114,6 +114,16 @@ class MocketTestCase(TestCase):
         buffer.seek(0)
         assert buffer.read() == b"Long payloadShort"
 
+    def test_makefile(self):
+        addr = ('localhost', 8080)
+        Mocket.register(MocketEntry(addr, ['Show me.\r\n']))
+        with Mocketizer():
+            sock = socket.create_connection(addr)
+            fp = sock.makefile('rb')
+            sock.sendall(encode_to_bytes('...\r\n'))
+            self.assertEqual(fp.read().strip(), encode_to_bytes('Show me.'))
+            self.assertEqual(len(Mocket._requests), 1)
+
 
 class MocketizeTestCase(TestCase):
     def mocketize_setup(self):


### PR DESCRIPTION
I think that the `MocketSocketCore` reference should be instantiated in `makefile()` rather then `sendall()`. Currently, `makefile` returns None, unless that is the intended behavior

You can test this change with the mocketoy example: https://github.com/mindflayer/mocketoy/pull/1

I don't know the ins-and-outs of mocket, so if this change makes sense, I can add tests and submit a more complete change. I just wanted to get input first