### PR TITLE
build: don't have pinned reqs for distributed package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: lint-python test-python
 safetest:
 	export SKIP_TRUE_REDIS=1; export SKIP_TRUE_HTTP=1; make test
 
-publish: install-test-requirements
+publish:
 	python setup.py sdist
 	twine upload dist/mocket-$(shell python -c 'import mocket; print(mocket.__version__)')*.*
 	anaconda upload dist/mocket-$(shell python -c 'import mocket; print(mocket.__version__)').tar.gz

--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-python-magic = "*"
-six = "*"
-decorator = "*"
-urllib3 = "*"
-http-parser = "*"
+mocket = {editable = true, path = "."}
 
 [dev-packages]
 pre-commit = "*"

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ os.environ.setdefault("PIPENV_SKIP_LOCK", "1")
 
 major, minor = sys.version_info[:2]
 
-install_requires = [
-    line
-    for line in io.open(
-        os.path.join(os.path.dirname(__file__), "requirements.txt")
-    ).readlines()
-    if not line.startswith("-i")
-]
+install_requires = (
+    "decorator>=4.4.2",
+    "http-parser>=0.9.0",
+    "python-magic>=0.4.18",
+    "six>=1.15.0",
+    "urllib3>=1.25.11",
+)
 
 pook_requires = ("pook>=0.2.1",)
 exclude_packages = ("tests", "tests.*")


### PR DESCRIPTION
A python package should not specify exact versions of it's dependencies
but should instead state the minimal compatible requirements for it's
dependencies.

Otherwise we end up in unresolvable dependecy situations (like I
find myself now with urllib3) where two packages require different
specific versions.  As of pip 20.3, which was released 2020-11-30, pip
will refuse to install conflicting dependecies.

You can read more about this here:
 - https://pipenv.pypa.io/en/latest/advanced/#pipfile-vs-setuppy
 - https://realpython.com/pipenv-guide/#package-distribution
 - https://blog.python.org/2020/11/pip-20-3-release-new-resolver.html