### PR TITLE
Avoid `decorator>=5` as dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 python-magic = ">=0.4.5"
-decorator = ">=4.0.0"
+decorator = ">=4.0.0,<5"
 urllib3 = ">=1.25.3"
 http-parser = ">=0.9.0"
 

--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -2,4 +2,4 @@ from mocket.mocket import Mocket, MocketEntry, Mocketizer, mocketize
 
 __all__ = ("mocketize", "Mocket", "MocketEntry", "Mocketizer")
 
-__version__ = "3.9.40"
+__version__ = "3.9.41"

--- a/tests/main/test_mocket.py
+++ b/tests/main/test_mocket.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
+import os
 import io
 import socket
 from unittest import TestCase
+from unittest.mock import patch
 
 import pytest
 
@@ -163,3 +165,12 @@ def fixture():
 @mocketize
 def test_mocketize_with_fixture(fixture):
     assert 2 == fixture
+
+
+@mocketize
+@patch("os.getcwd")
+def test_patch(
+    method_patch,
+):
+    method_patch.return_value = 'foo'
+    assert os.getcwd() == "foo"


### PR DESCRIPTION
At least until [this](https://github.com/micheles/decorator/issues/126) is resolved.

Fix for #148.