### PR TITLE
Fixes for allowing making a mixture of unmocked and mocked HTTPS requests using aiohttp

### DIFF
--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -85,6 +85,7 @@ class FakeSSLContext(SuperFakeSSLContext):
         "load_verify_locations",
         "set_alpn_protocols",
         "set_ciphers",
+        "set_default_verify_paths",
     )
     sock = None
     post_handshake_auth = None

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -49,6 +49,13 @@ try:  # pragma: no cover
 except ImportError:
     pyopenssl_override = False
 
+try:  # pragma: no cover
+    from aiohttp import TCPConnector
+
+    aiohttp_make_ssl_context_cache_clear = TCPConnector._make_ssl_context.cache_clear
+except (ImportError, AttributeError):
+    aiohttp_make_ssl_context_cache_clear = None
+
 
 true_socket = socket.socket
 true_create_connection = socket.create_connection
@@ -548,6 +555,8 @@ class Mocket:
         if pyopenssl_override:  # pragma: no cover
             # Take out the pyopenssl version - use the default implementation
             extract_from_urllib3()
+        if aiohttp_make_ssl_context_cache_clear:  # pragma: no cover
+            aiohttp_make_ssl_context_cache_clear()
 
     @staticmethod
     def disable():
@@ -584,6 +593,8 @@ class Mocket:
         if pyopenssl_override:  # pragma: no cover
             # Put the pyopenssl version back in place
             inject_into_urllib3()
+        if aiohttp_make_ssl_context_cache_clear:  # pragma: no cover
+            aiohttp_make_ssl_context_cache_clear()
 
     @classmethod
     def get_namespace(cls):

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -304,7 +304,14 @@ class MocketSocket:
         return rv
 
     def recv_into(self, buffer, buffersize=None, flags=None):
-        return buffer.write(self.read(buffersize))
+        if hasattr(buffer, "write"):
+            return buffer.write(self.read(buffersize))
+        else:
+            # buffer is a memoryview
+            data = self.read(buffersize)
+            if data:
+                buffer[: len(data)] = data
+            return len(data)
 
     def recv(self, buffersize, flags=None):
         if Mocket.r_fd and Mocket.w_fd:

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -257,6 +257,8 @@ class MocketSocket:
 
     @staticmethod
     def fileno():
+        if Mocket.r_fd is not None:
+            return Mocket.r_fd
         Mocket.r_fd, Mocket.w_fd = os.pipe()
         return Mocket.r_fd
 
@@ -455,8 +457,12 @@ class Mocket:
 
     @classmethod
     def reset(cls):
-        cls.r_fd = None
-        cls.w_fd = None
+        if cls.r_fd is not None:
+            os.close(cls.r_fd)
+            cls.r_fd = None
+        if cls.w_fd is not None:
+            os.close(cls.w_fd)
+            cls.w_fd = None
         cls._entries = collections.defaultdict(list)
         cls._requests = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pre-commit",
+    "psutil",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",

--- a/tests/tests38/test_http_aiohttp.py
+++ b/tests/tests38/test_http_aiohttp.py
@@ -1,7 +1,6 @@
 import json
 from unittest import IsolatedAsyncioTestCase
 
-import httpx
 import pytest
 
 from mocket.async_mocket import async_mocketize
@@ -80,22 +79,3 @@ if ENABLE_TEST_CLASS:
                 async with session.get(self.target_url) as get_response:
                     assert get_response.status == 200
                     assert await get_response.text() == '{"origin": "127.0.0.1"}'
-
-
-class HttpxEntryTestCase(IsolatedAsyncioTestCase):
-    target_url = "http://httpbin.local/ip"
-
-    @async_httprettified
-    async def test_httprettish_httpx_session(self):
-        expected_response = {"origin": "127.0.0.1"}
-
-        HTTPretty.register_uri(
-            HTTPretty.GET,
-            self.target_url,
-            body=json.dumps(expected_response),
-        )
-
-        async with httpx.AsyncClient() as client:
-            response = await client.get(self.target_url)
-            assert response.status_code == 200
-            assert response.json() == expected_response

--- a/tests/tests38/test_http_aiohttp.py
+++ b/tests/tests38/test_http_aiohttp.py
@@ -81,6 +81,14 @@ if ENABLE_TEST_CLASS:
 
             self.assertEqual(len(Mocket.request_list()), 2)
 
+        @async_mocketize
+        async def test_no_verify(self):
+            Entry.single_register(Entry.GET, self.target_url, status=404)
+
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.get(self.target_url, ssl=False) as get_response:
+                    assert get_response.status == 404
+
         @async_httprettified
         async def test_httprettish_session(self):
             HTTPretty.register_uri(

--- a/tests/tests38/test_http_httpx.py
+++ b/tests/tests38/test_http_httpx.py
@@ -23,3 +23,22 @@ class HttpxEntryTestCase(IsolatedAsyncioTestCase):
             response = await client.get(self.target_url)
             assert response.status_code == 200
             assert response.json() == expected_response
+
+
+class HttpxHttpsEntryTestCase(IsolatedAsyncioTestCase):
+    target_url = "https://httpbin.local/ip"
+
+    @async_httprettified
+    async def test_httprettish_httpx_session(self):
+        expected_response = {"origin": "127.0.0.1"}
+
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            self.target_url,
+            body=json.dumps(expected_response),
+        )
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self.target_url)
+            assert response.status_code == 200
+            assert response.json() == expected_response

--- a/tests/tests38/test_http_httpx.py
+++ b/tests/tests38/test_http_httpx.py
@@ -1,0 +1,25 @@
+import json
+from unittest import IsolatedAsyncioTestCase
+
+import httpx
+
+from mocket.plugins.httpretty import HTTPretty, async_httprettified
+
+
+class HttpxEntryTestCase(IsolatedAsyncioTestCase):
+    target_url = "http://httpbin.local/ip"
+
+    @async_httprettified
+    async def test_httprettish_httpx_session(self):
+        expected_response = {"origin": "127.0.0.1"}
+
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            self.target_url,
+            body=json.dumps(expected_response),
+        )
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self.target_url)
+            assert response.status_code == 200
+            assert response.json() == expected_response


### PR DESCRIPTION
This PR attempts to fix a few issues:

In a project I'm working with, a mocketized test would fail if it ran after a test that makes a real HTTPS request. Both use aiohttp. Clearing [aiohttp's internal cache](https://github.com/aio-libs/aiohttp/blob/v3.9.1/aiohttp/connector.py#L915-L917) that holds an SSLContext object fixed the issue.

I encountered more issues while trying to write a PR for the above:
* Saw that I get a 'too many open files' error when I was experimenting with running the same test many times through parameterization.
  * Fixed by returning existing `Mocket.r_fd` from `MocketSocket.fileno` if it's already set and closing the pipe's file descriptors when resetting Mocket
* Testing HTTPS test cases that use aiohttp with Python 3.11 just wouldn't pass - same error as  #209
  * I think this is because Python 3.11's asyncio module tries to receive bytes from the remote end right after completing SSL handshake. With a real HTTPS connection, [`SSLWantReadError`](https://github.com/python/cpython/blob/e58334e4c9ccbebce6858da1985c1f75a6063d05/Modules/_ssl.c#L429) gets raised and [get retried later](https://github.com/python/cpython/blob/v3.11.7/Lib/asyncio/sslproto.py#L790). With Mocket, it returns an empty string in that case, which [causes the connection to get shut down](https://github.com/python/cpython/blob/v3.11.7/Lib/asyncio/sslproto.py#L796-L799). Tracing function calls using [hunter](https://pypi.org/project/hunter/) was helpful in determining the cause here.
  * Fixed by keeping track of whether SSL handshake has occurred and whether Mocket has sent back non-empty bytes and raising `SSLWantReadError` when SSL handshake occurred and no bytes have been sent back yet. This works with my project's test suite, but admittedly I'm not sure if there's a case where this would cause an infinite loop waiting for a response or some other failure. But I guess that'd correspond to timeouts, which are something that can happen in real-life scenarios too.
* Another change in Python 3.11's asyncio module: `MocketSocket.recv_into` may receive a memorybuffer object
  * Fixed by branching on whether the buffer object has a `write` attribute
* Calling aiohttp's API with `ssl=False` failed because it calls a method on SSLContext object that wasn't mocked by Mocket
  * Added the method to `FakeSSLContext.DUMMY_METHODS`