### PR TITLE
Allow specifying strict mode exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,20 @@ NEW!!! Sometimes you just want your tests to fail when they attempt to use the n
         with pytest.raises(StrictMocketException):
             requests.get("https://duckduckgo.com/")
 
+You can specify exceptions as a list of hosts or host-port pairs.
+
+.. code-block:: python
+
+    with Mocketizer(strict_mode=True, strict_mode_allowed=["localhost", ("intake.ourmetrics.net", 443)]):
+        ...
+
+    # OR
+
+    @mocketize(strict_mode=True, strict_mode_allowed=["localhost", ("intake.ourmetrics.net", 443)])
+    def test_get():
+        ...
+
+
 How to be sure that all the Entry instances have been served?
 =============================================================
 Add this instruction at the end of the test execution:

--- a/mocket/async_mocket.py
+++ b/mocket/async_mocket.py
@@ -3,9 +3,16 @@ from .utils import get_mocketize
 
 
 async def wrapper(
-    test, truesocket_recording_dir=None, strict_mode=False, *args, **kwargs
+    test,
+    truesocket_recording_dir=None,
+    strict_mode=False,
+    strict_mode_allowed=None,
+    *args,
+    **kwargs
 ):
-    async with Mocketizer.factory(test, truesocket_recording_dir, strict_mode, args):
+    async with Mocketizer.factory(
+        test, truesocket_recording_dir, strict_mode, strict_mode_allowed, args
+    ):
         return await test(*args, **kwargs)
 
 

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -312,8 +312,19 @@ class MocketSocket:
     def true_sendall(self, data, *args, **kwargs):
         if MocketMode().STRICT:
             if not MocketMode().allowed((self._host, self._port)):
+                current_entries = [
+                    (location, "\n    ".join(map(str, entries)))
+                    for location, entries in Mocket._entries.items()
+                ]
+                formatted_entries = "\n".join(
+                    [
+                        f"  {location}:\n    {entries}"
+                        for location, entries in current_entries
+                    ]
+                )
                 raise StrictMocketException(
-                    "Mocket tried to use the real `socket` module."
+                    "Mocket tried to use the real `socket` module while strict mode is active.\n"
+                    f"Registered entries:\n{formatted_entries}"
                 )
 
         req = decode_from_bytes(data)
@@ -613,6 +624,9 @@ class MocketEntry:
                         r = encode_to_bytes(r)
                     r = self.response_cls(r)
                 self.responses.append(r)
+
+    def __repr__(self):
+        return "{}(location={})".format(self.__class__.__name__, self.location)
 
     @staticmethod
     def can_handle(data):

--- a/mocket/mockhttp.py
+++ b/mocket/mockhttp.py
@@ -175,6 +175,18 @@ class Entry(MocketEntry):
         self._sent_data = b""
         self._match_querystring = match_querystring
 
+    def __repr__(self):
+        return (
+            "{}(method={!r}, schema={!r}, location={!r}, path={!r}, query={!r})".format(
+                self.__class__.__name__,
+                self.method,
+                self.schema,
+                self.location,
+                self.path,
+                self.query,
+            )
+        )
+
     def collect(self, data):
         consume_response = True
 

--- a/mocket/utils.py
+++ b/mocket/utils.py
@@ -47,6 +47,18 @@ def get_mocketize(wrapper_):
 class MocketMode:
     __shared_state = {}
     STRICT = None
+    STRICT_ALLOWED = None
 
     def __init__(self):
         self.__dict__ = self.__shared_state
+
+    def allowed(self, location):
+        if not self.STRICT_ALLOWED:
+            return False
+        host, port = location
+        for allowed in self.STRICT_ALLOWED:
+            if isinstance(allowed, str) and host == allowed:
+                return True
+            elif location == allowed:
+                return True
+        return False

--- a/tests/main/test_mode.py
+++ b/tests/main/test_mode.py
@@ -26,3 +26,14 @@ def test_intermittent_strict_mode():
 
     with Mocketizer(strict_mode=False):
         requests.get(url)
+
+
+@pytest.mark.skipif('os.getenv("SKIP_TRUE_HTTP", False)')
+def test_strict_mode_exceptions():
+    url = "http://httpbin.local/ip"
+
+    with Mocketizer(strict_mode=True, strict_mode_allowed=["httpbin.local"]):
+        requests.get(url)
+
+    with Mocketizer(strict_mode=True, strict_mode_allowed=[("httpbin.local", 80)]):
+        requests.get(url)

--- a/tests/main/test_mode.py
+++ b/tests/main/test_mode.py
@@ -3,6 +3,7 @@ import requests
 
 from mocket import Mocketizer, mocketize
 from mocket.exceptions import StrictMocketException
+from mocket.mockhttp import Entry, Response
 
 
 @mocketize(strict_mode=True)
@@ -37,3 +38,22 @@ def test_strict_mode_exceptions():
 
     with Mocketizer(strict_mode=True, strict_mode_allowed=[("httpbin.local", 80)]):
         requests.get(url)
+
+
+def test_strict_mode_error_message():
+    url = "http://httpbin.local/ip"
+
+    Entry.register(Entry.GET, "http://httpbin.local/user.agent", Response(status=404))
+
+    with Mocketizer(strict_mode=True):
+        with pytest.raises(StrictMocketException) as exc_info:
+            requests.get(url)
+        assert (
+            str(exc_info.value)
+            == """
+Mocket tried to use the real `socket` module while strict mode is active.
+Registered entries:
+  ('httpbin.local', 80):
+    Entry(method='GET', schema='http', location=('httpbin.local', 80), path='/user.agent', query='')
+""".strip()
+        )


### PR DESCRIPTION
I'm trying to use a library that sends test stats to a remote server in the background, and tests that use Mocket in strict mode would fail intermittently when the library tries to make an HTTP request.

This PR adds a new `strict_mode_allowed: list[str | tuple[str, int]]` parameter to `Mocketizer`, which specifies which host or host and port can be made requests against even in strict mode.

Suggestions for a better name for the parameter would be welcome, if any. What some other libraries use...
- [HTTPretty's unmerged PR](https://github.com/gabrielfalcao/HTTPretty/pull/448/files): `whitelist`
- [WebMock, a Ruby library](https://github.com/bblimke/webmock#external-requests-can-be-disabled-while-allowing-specific-requests): `allow`