### PR TITLE
Begin mypy type-checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ lint-python:
 	flake8 --ignore=E501,E731,W503 --exclude=.git,compat.py --per-file-ignores='mocket/async_mocket.py:E999' mocket
 	@echo ""
 
+types:
+	@echo "Type checking Python files"
+	mypy --pretty
+	@echo ""
+
 setup: develop
 	pre-commit install
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ setup: develop
 
 develop: install-dev-requirements install-test-requirements
 
-test: lint-python test-python
+test: lint-python types test-python
 
 safetest:
 	export SKIP_TRUE_REDIS=1; export SKIP_TRUE_HTTP=1; make test

--- a/mocket/compat.py
+++ b/mocket/compat.py
@@ -1,27 +1,30 @@
+from __future__ import annotations
+
 import codecs
 import os
 import shlex
+from typing import Final, Any
 
-ENCODING = os.getenv("MOCKET_ENCODING", "utf-8")
+ENCODING: Final[str] = os.getenv("MOCKET_ENCODING", "utf-8")
 
 text_type = str
 byte_type = bytes
 basestring = (str,)
 
 
-def encode_to_bytes(s, encoding=ENCODING):
+def encode_to_bytes(s: str | bytes, encoding: str = ENCODING) -> bytes:
     if isinstance(s, text_type):
         s = s.encode(encoding)
     return byte_type(s)
 
 
-def decode_from_bytes(s, encoding=ENCODING):
+def decode_from_bytes(s: str | bytes, encoding: str = ENCODING) -> str:
     if isinstance(s, byte_type):
         s = codecs.decode(s, encoding, "ignore")
     return text_type(s)
 
 
-def shsplit(s):
+def shsplit(s: str | bytes) -> list[str]:
     s = decode_from_bytes(s)
     return shlex.split(s)
 

--- a/mocket/utils.py
+++ b/mocket/utils.py
@@ -1,17 +1,26 @@
+from __future__ import annotations
+
 import binascii
 import io
 import os
 import ssl
-from typing import Tuple, Union
+from typing import Tuple, Union, Callable, TYPE_CHECKING, TypeVar, Any, ClassVar
+from typing_extensions import override
 
 from .compat import decode_from_bytes, encode_to_bytes
 from .exceptions import StrictMocketException
 
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+    from typing_extensions import NoReturn
+
 SSL_PROTOCOL = ssl.PROTOCOL_TLSv1_2
 
+T = TypeVar("T")
 
 class MocketSocketCore(io.BytesIO):
-    def write(self, content):
+    @override
+    def write(self, content: ReadableBuffer) -> None:  # type: ignore[override] # BytesIO returns int
         super(MocketSocketCore, self).write(content)
 
         from mocket import Mocket
@@ -20,7 +29,7 @@ class MocketSocketCore(io.BytesIO):
             os.write(Mocket.w_fd, content)
 
 
-def hexdump(binary_string):
+def hexdump(binary_string: bytes)  -> str:
     r"""
     >>> hexdump(b"bar foobar foo") == decode_from_bytes(encode_to_bytes("62 61 72 20 66 6F 6F 62 61 72 20 66 6F 6F"))
     True
@@ -29,7 +38,7 @@ def hexdump(binary_string):
     return " ".join(a + b for a, b in zip(bs[::2], bs[1::2]))
 
 
-def hexload(string):
+def hexload(string: str) -> bytes:
     r"""
     >>> hexload("62 61 72 20 66 6F 6F 62 61 72 20 66 6F 6F") == encode_to_bytes("bar foobar foo")
     True
@@ -38,20 +47,20 @@ def hexload(string):
     return encode_to_bytes(binascii.unhexlify(string_no_spaces))
 
 
-def get_mocketize(wrapper_):
+def get_mocketize(wrapper_: T) -> T:
     import decorator
 
-    if decorator.__version__ < "5":  # pragma: no cover
+    if decorator.__version__ < "5":   # type: ignore[attr-defined] # pragma: no cover
         return decorator.decorator(wrapper_)
     return decorator.decorator(wrapper_, kwsyntax=True)
 
 
 class MocketMode:
-    __shared_state = {}
-    STRICT = None
-    STRICT_ALLOWED = None
+    __shared_state: ClassVar[dict[str, Any]] = {}
+    STRICT: ClassVar = None
+    STRICT_ALLOWED: ClassVar = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__dict__ = self.__shared_state
 
     def is_allowed(self, location: Union[str, Tuple[str, int]]) -> bool:
@@ -65,7 +74,7 @@ class MocketMode:
         return location in self.STRICT_ALLOWED or host in self.STRICT_ALLOWED
 
     @staticmethod
-    def raise_not_allowed():
+    def raise_not_allowed() -> NoReturn:
         from .mocket import Mocket
 
         current_entries = [

--- a/mocket/utils.py
+++ b/mocket/utils.py
@@ -47,7 +47,7 @@ def hexload(string: str) -> bytes:
     return encode_to_bytes(binascii.unhexlify(string_no_spaces))
 
 
-def get_mocketize(wrapper_: T) -> T:
+def get_mocketize(wrapper_: Callable) -> Callable:
     import decorator
 
     if decorator.__version__ < "5":   # type: ignore[attr-defined] # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "twine",
     "fastapi",
     "wait-for-it",
+    "mypy",
 ]
 speedups = [
     "xxhash;platform_python_implementation=='CPython'",
@@ -81,3 +82,20 @@ include = [
 exclude = [
   ".*",
 ]
+
+[tool.mypy]
+python_version = "3.8"
+files = ["mocket/", "tests/"]
+strict = true
+warn_unused_configs = true
+ignore_missing_imports = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_codes = true
+implicit_reexport = false
+disallow_any_generics = true
+enable_error_code = ['ignore-without-code', 'explicit-override']
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disable_error_code = ['type-arg', 'no-untyped-def']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,10 @@ exclude = [
 
 [tool.mypy]
 python_version = "3.8"
-files = ["mocket/", "tests/"]
+files = [
+    "mocket/utils.py", 
+    # "tests/"
+    ]
 strict = true
 warn_unused_configs = true
 ignore_missing_imports = true
@@ -94,6 +97,7 @@ warn_unused_ignores = true
 show_error_codes = true
 implicit_reexport = false
 disallow_any_generics = true
+follow_imports = "silent"  # enable this once majority is typed
 enable_error_code = ['ignore-without-code', 'explicit-override']
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ exclude = [
 [tool.mypy]
 python_version = "3.8"
 files = [
+    "mocket/compat.py",
     "mocket/utils.py", 
     # "tests/"
     ]
@@ -100,6 +101,7 @@ implicit_reexport = false
 disallow_any_generics = false
 follow_imports = "silent"  # enable this once majority is typed
 enable_error_code = ['ignore-without-code', 'explicit-override']
+disable_error_code = ["no-untyped-def"] # enable this once full type-coverage is reached
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
     "fastapi",
     "wait-for-it",
     "mypy",
+    "types-decorator",
 ]
 speedups = [
     "xxhash;platform_python_implementation=='CPython'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 show_error_codes = true
 implicit_reexport = false
-disallow_any_generics = true
+disallow_any_generics = false
 follow_imports = "silent"  # enable this once majority is typed
 enable_error_code = ['ignore-without-code', 'explicit-override']
 


### PR DESCRIPTION
Begin minimal type-checking of the codebase as part of the effort to export type hints.
- #203 
- Add `make types` item
- Add `types` to `make tests` step that runs in ci
- Type checking of select modules
  - utils
  - compat
  - ... 