### PR TITLE
`aiohttp` reuses SSLContext instances created at import-time

### DIFF
--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -1,6 +1,13 @@
 from .async_mocket import async_mocketize
-from .mocket import Mocket, MocketEntry, Mocketizer, mocketize
+from .mocket import FakeSSLContext, Mocket, MocketEntry, Mocketizer, mocketize
 
-__all__ = ("async_mocketize", "mocketize", "Mocket", "MocketEntry", "Mocketizer")
+__all__ = (
+    "async_mocketize",
+    "mocketize",
+    "Mocket",
+    "MocketEntry",
+    "Mocketizer",
+    "FakeSSLContext",
+)
 
 __version__ = "3.13.1"

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -25,7 +25,6 @@ except ImportError:
 
 from .compat import basestring, byte_type, decode_from_bytes, encode_to_bytes, text_type
 from .utils import (
-    SSL_PROTOCOL,
     MocketMode,
     MocketSocketCore,
     get_mocketize,
@@ -98,19 +97,8 @@ class FakeSSLContext(SuperFakeSSLContext):
     def check_hostname(self, _):
         self._check_hostname = False
 
-    def __init__(self, sock=None, server_hostname=None, _context=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._set_dummy_methods()
-
-        if isinstance(sock, MocketSocket):
-            self.sock = sock
-            self.sock._host = server_hostname
-            self.sock.true_socket = true_ssl_socket(
-                sock=self.sock.true_socket,
-                server_hostname=server_hostname,
-                _context=true_ssl_context(protocol=SSL_PROTOCOL),
-            )
-        elif isinstance(sock, int) and true_ssl_context:
-            self.context = true_ssl_context(sock)
 
     def _set_dummy_methods(self):
         def dummy_method(*args, **kwargs):
@@ -120,7 +108,7 @@ class FakeSSLContext(SuperFakeSSLContext):
             setattr(self, m, dummy_method)
 
     @staticmethod
-    def wrap_socket(sock=sock, *args, **kwargs):
+    def wrap_socket(sock, *args, **kwargs):
         sock.kwargs = kwargs
         sock._secure_socket = True
         return sock
@@ -130,10 +118,6 @@ class FakeSSLContext(SuperFakeSSLContext):
         ssl_obj = MocketSocket()
         ssl_obj._host = kwargs["server_hostname"]
         return ssl_obj
-
-    def __getattr__(self, name):
-        if self.sock is not None:
-            return getattr(self.sock, name)
 
 
 def create_connection(address, timeout=None, source_address=None):

--- a/mocket/plugins/aiohttp_connector.py
+++ b/mocket/plugins/aiohttp_connector.py
@@ -1,10 +1,9 @@
 import contextlib
 
-from aiohttp import ClientRequest
-
 from mocket import FakeSSLContext
 
 with contextlib.suppress(ModuleNotFoundError):
+    from aiohttp import ClientRequest
     from aiohttp.connector import TCPConnector
 
     class MocketTCPConnector(TCPConnector):

--- a/mocket/plugins/aiohttp_connector.py
+++ b/mocket/plugins/aiohttp_connector.py
@@ -1,0 +1,19 @@
+import contextlib
+
+from aiohttp import ClientRequest
+
+from mocket import FakeSSLContext
+
+with contextlib.suppress(ModuleNotFoundError):
+    from aiohttp.connector import TCPConnector
+
+    class MocketTCPConnector(TCPConnector):
+        """
+        `aiohttp` reuses SSLContext instances created at import-time,
+        making it more difficult for Mocket to do its job.
+        This is an attempt to make things smoother, at the cost of
+        slightly patching the `ClientSession` while testing.
+        """
+
+        def _get_ssl_context(self, req: ClientRequest) -> FakeSSLContext:
+            return FakeSSLContext()

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -4,10 +4,12 @@ import json
 import socket
 import tempfile
 
+import aiohttp
 import pytest
 
 from mocket import Mocketizer, async_mocketize
 from mocket.mockhttp import Entry
+from mocket.plugins.aiohttp_connector import MocketTCPConnector
 
 
 def test_asyncio_record_replay(event_loop):
@@ -45,8 +47,6 @@ def test_asyncio_record_replay(event_loop):
 @pytest.mark.asyncio
 @async_mocketize
 async def test_aiohttp():
-    import aiohttp
-
     url = "https://bar.foo/"
     data = {"message": "Hello"}
 
@@ -58,7 +58,7 @@ async def test_aiohttp():
     )
 
     async with aiohttp.ClientSession(
-        timeout=aiohttp.ClientTimeout(total=3)
+        timeout=aiohttp.ClientTimeout(total=3), connector=MocketTCPConnector()
     ) as session, session.get(url) as response:
         response = await response.json()
         assert response == data

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -47,6 +47,11 @@ def test_asyncio_record_replay(event_loop):
 @pytest.mark.asyncio
 @async_mocketize
 async def test_aiohttp():
+    """
+    The alternative to using the custom `connector` would be importing
+    `aiohttp` when Mocket is already in control (inside the decorated test).
+    """
+
     url = "https://bar.foo/"
     data = {"message": "Hello"}
 


### PR DESCRIPTION
This in a small tool to make things work when Mocket gets stuck during testing with `aiohttp`.
Kinda fix for #247.