### PR TITLE
Build and publish pure python wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ safetest:
 	export SKIP_TRUE_REDIS=1; export SKIP_TRUE_HTTP=1; make test
 
 publish: clean install-test-requirements
-	uv run python3 -m build --sdist .
-	uv run twine upload --repository mocket dist/*.tar.gz
+	uv run python3 -m build --sdist --wheel .
+	uv run twine upload --repository mocket dist/
 
 clean:
 	rm -rf .coverage *.egg-info dist/ requirements.txt uv.lock || true


### PR DESCRIPTION
👋 I'm using mocket from inside pyodide and pyodide requires ["pure python wheels"](https://pyodide.org/en/stable/usage/faq.html#why-can-t-micropip-find-a-pure-python-wheel-for-a-package) to be able to install a given package. 

I saw that mocket currently publishes only an sdist and not a pure python wheel, so making this PR to add a pure python wheel as well.

I tested out the change and it seems to work:

```
@wilhelmklopp ➜ /workspaces/python-mocket (build-pure-python-wheel) $ uv run python3 -m build --sdist --wheel .
* Creating isolated environment: virtualenv+pip...
* Installing packages in isolated environment:
  - hatchling>=1.22.2
* Getting build dependencies for sdist...
* Building sdist...
* Creating isolated environment: virtualenv+pip...
* Installing packages in isolated environment:
  - hatchling>=1.22.2
* Getting build dependencies for wheel...
* Building wheel...
Successfully built mocket-3.13.2.tar.gz and mocket-3.13.2-py3-none-any.whl
@wilhelmklopp ➜ /workspaces/python-mocket (build-pure-python-wheel) $ ls -lh dist/
total 96K
-rw-r--r-- 1 codespace codespace 22K Nov  2 17:56 mocket-3.13.2-py3-none-any.whl
-rw-r--r-- 1 codespace codespace 72K Nov  2 17:56 mocket-3.13.2.tar.gz
```

To be honest, before running into this issue I didn't know much about _pure python_ wheels, but it seems like they've been around for a number of years and [their use is encouraged](https://pradyunsg.me/blog/2022/12/31/wheels-are-faster-pure-python/). [More docs](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pure-python-wheels).

I asked Claude to see if there are any _downsides_ to publishing a pure python wheel alongside an sdist and it couldn't come up with anything beyond "now two files need to be uploaded to PyPI". It's encouraging to see that the pure python wheel is also smaller in size (22K vs 72K) meaning all mocket users should benefit from this change with less data traveling over the network and faster install time.