### PR TITLE
Refactor rename ssl classes

### DIFF
--- a/mocket/__init__.py
+++ b/mocket/__init__.py
@@ -2,7 +2,10 @@ from mocket.async_mocket import async_mocketize
 from mocket.entry import MocketEntry
 from mocket.mocket import Mocket
 from mocket.mocketizer import Mocketizer, mocketize
-from mocket.ssl.context import FakeSSLContext
+from mocket.ssl.context import MocketSSLContext
+
+# NOTE this is here for backwards-compat to keep old import-paths working
+from mocket.ssl.context import MocketSSLContext as FakeSSLContext
 
 __all__ = (
     "async_mocketize",
@@ -10,6 +13,7 @@ __all__ = (
     "Mocket",
     "MocketEntry",
     "Mocketizer",
+    "MocketSSLContext",
     "FakeSSLContext",
 )
 

--- a/mocket/inject.py
+++ b/mocket/inject.py
@@ -29,7 +29,7 @@ def enable(
         mock_socketpair,
         mock_urllib3_match_hostname,
     )
-    from mocket.ssl.context import FakeSSLContext
+    from mocket.ssl.context import MocketSSLContext
 
     Mocket._namespace = namespace
     Mocket._truesocket_recording_dir = truesocket_recording_dir
@@ -48,21 +48,21 @@ def enable(
     socket.gethostbyname = socket.__dict__["gethostbyname"] = mock_gethostbyname
     socket.getaddrinfo = socket.__dict__["getaddrinfo"] = mock_getaddrinfo
     socket.socketpair = socket.__dict__["socketpair"] = mock_socketpair
-    ssl.wrap_socket = ssl.__dict__["wrap_socket"] = FakeSSLContext.wrap_socket
-    ssl.SSLContext = ssl.__dict__["SSLContext"] = FakeSSLContext
+    ssl.wrap_socket = ssl.__dict__["wrap_socket"] = MocketSSLContext.wrap_socket
+    ssl.SSLContext = ssl.__dict__["SSLContext"] = MocketSSLContext
     socket.inet_pton = socket.__dict__["inet_pton"] = mock_inet_pton
     urllib3.util.ssl_.wrap_socket = urllib3.util.ssl_.__dict__["wrap_socket"] = (
-        FakeSSLContext.wrap_socket
+        MocketSSLContext.wrap_socket
     )
     urllib3.util.ssl_.ssl_wrap_socket = urllib3.util.ssl_.__dict__[
         "ssl_wrap_socket"
-    ] = FakeSSLContext.wrap_socket
+    ] = MocketSSLContext.wrap_socket
     urllib3.util.ssl_wrap_socket = urllib3.util.__dict__["ssl_wrap_socket"] = (
-        FakeSSLContext.wrap_socket
+        MocketSSLContext.wrap_socket
     )
     urllib3.connection.ssl_wrap_socket = urllib3.connection.__dict__[
         "ssl_wrap_socket"
-    ] = FakeSSLContext.wrap_socket
+    ] = MocketSSLContext.wrap_socket
     urllib3.connection.match_hostname = urllib3.connection.__dict__[
         "match_hostname"
     ] = mock_urllib3_match_hostname

--- a/mocket/io.py
+++ b/mocket/io.py
@@ -4,7 +4,7 @@ import os
 from mocket.mocket import Mocket
 
 
-class MocketSocketCore(io.BytesIO):
+class MocketSocketIO(io.BytesIO):
     def __init__(self, address) -> None:
         self._address = address
         super().__init__()

--- a/mocket/plugins/aiohttp_connector.py
+++ b/mocket/plugins/aiohttp_connector.py
@@ -1,6 +1,6 @@
 import contextlib
 
-from mocket import FakeSSLContext
+from mocket import MocketSSLContext
 
 with contextlib.suppress(ModuleNotFoundError):
     from aiohttp import ClientRequest
@@ -14,5 +14,5 @@ with contextlib.suppress(ModuleNotFoundError):
         slightly patching the `ClientSession` while testing.
         """
 
-        def _get_ssl_context(self, req: ClientRequest) -> FakeSSLContext:
-            return FakeSSLContext()
+        def _get_ssl_context(self, req: ClientRequest) -> MocketSSLContext:
+            return MocketSSLContext()

--- a/mocket/socket.py
+++ b/mocket/socket.py
@@ -18,7 +18,7 @@ from typing_extensions import Self
 
 from mocket.compat import decode_from_bytes, encode_to_bytes
 from mocket.entry import MocketEntry
-from mocket.io import MocketSocketCore
+from mocket.io import MocketSocketIO
 from mocket.mocket import Mocket
 from mocket.mode import MocketMode
 from mocket.types import (
@@ -148,9 +148,9 @@ class MocketSocket:
         return self._proto
 
     @property
-    def io(self) -> MocketSocketCore:
+    def io(self) -> MocketSocketIO:
         if self._io is None:
-            self._io = MocketSocketCore((self._host, self._port))
+            self._io = MocketSocketIO((self._host, self._port))
         return self._io
 
     def fileno(self) -> int:
@@ -196,7 +196,7 @@ class MocketSocket:
         self._address = self._host, self._port = address
         Mocket._address = address
 
-    def makefile(self, mode: str = "r", bufsize: int = -1) -> MocketSocketCore:
+    def makefile(self, mode: str = "r", bufsize: int = -1) -> MocketSocketIO:
         return self.io
 
     def get_entry(self, data: bytes) -> MocketEntry | None:

--- a/mocket/ssl/context.py
+++ b/mocket/ssl/context.py
@@ -27,7 +27,7 @@ with contextlib.suppress(ImportError):
     true_urllib3_wrap_socket = urllib3_wrap_socket
 
 
-class SuperFakeSSLContext:
+class _MocketSSLContext:
     """For Python 3.6 and newer."""
 
     class FakeSetter(int):
@@ -40,7 +40,7 @@ class SuperFakeSSLContext:
     verify_flags = FakeSetter()
 
 
-class FakeSSLContext(SuperFakeSSLContext):
+class MocketSSLContext(_MocketSSLContext):
     DUMMY_METHODS = (
         "load_default_certs",
         "load_verify_locations",

--- a/mocket/utils.py
+++ b/mocket/utils.py
@@ -7,7 +7,7 @@ from typing import Callable
 from mocket.compat import decode_from_bytes, encode_to_bytes
 
 # NOTE this is here for backwards-compat to keep old import-paths working
-from mocket.io import MocketSocketCore as MocketSocketCore
+from mocket.io import MocketSocketIO as MocketSocketCore
 
 # NOTE this is here for backwards-compat to keep old import-paths working
 from mocket.mode import MocketMode as MocketMode


### PR DESCRIPTION
this PR renames some classes while re-exporting the old names for backwards-compat.

- `MocketSocketCore` -> `MocketSocketIO`
- `FakeSSLContext` -> `MocketSSLContext`
- `SuperFakeContext` -> `_MocketSSLContext`

reason being: align with class-naming in python stdlib to make it more obvious what is being mocked.