### PR TITLE
Target `make safetest` got broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ types:
 test: types
 	@echo "Running Python tests"
 	uv pip uninstall pook || true
-	export VIRTUAL_ENV=.venv; .venv/bin/wait-for-it --service httpbin.local:443 --service localhost:6379 --timeout 5 -- .venv/bin/pytest
+	.venv/bin/wait-for-it --service httpbin.local:443 --service localhost:6379 --timeout 5 -- .venv/bin/pytest
 	uv pip install pook && .venv/bin/pytest tests/test_pook.py && uv pip uninstall pook
 	@echo ""
 
 safetest:
-	export SKIP_TRUE_REDIS=1; export SKIP_TRUE_HTTP=1; make test
+	export SKIP_TRUE_REDIS=1; export SKIP_TRUE_HTTP=1; .venv/bin/pytest
 
 publish: clean install-test-requirements
 	uv run python3 -m build --sdist --wheel .

--- a/tests/test_mocket.py
+++ b/tests/test_mocket.py
@@ -222,6 +222,7 @@ def test_patch(
 
 
 @pytest.mark.skipif(not psutil.POSIX, reason="Uses a POSIX-only API to test")
+@pytest.mark.skipif('os.getenv("SKIP_TRUE_HTTP", False)')
 @pytest.mark.asyncio
 async def test_no_dangling_fds():
     url = "http://httpbin.local/ip"

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -158,9 +158,11 @@ class RedisTestCase(TestCase):
         self.rclient = redis.StrictRedis()
 
     def mocketize_setup(self):
+        Entry.register_response("CLIENT SETINFO LIB-NAME redis-py", OK)
+        Entry.register_response(f"CLIENT SETINFO LIB-VER {redis.__version__}", OK)
         Entry.register_response("FLUSHDB", OK)
         self.rclient.flushdb()
-        self.assertEqual(len(Mocket.request_list()), 1)
+        self.assertEqual(len(Mocket.request_list()), 3)
         Mocket.reset()
 
     @mocketize


### PR DESCRIPTION
It used to be possible to only run the tests relying on Mocket - non-real `socket` ones - but it looks like something changed in the Redis client that is worth investigating (something more needs to be mocked).

It helps to overcome issues like the one mentioned in #272

See https://redis.io/docs/latest/commands/client-setinfo/