### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ As second step, we create an `example.py` file as the following one:
     import json
 
     from mocket import mocketize
-    from mocket.mockhttp import Entry
+    from mocket.mocks.mockhttp import Entry
     import requests
     import pytest
 
@@ -294,7 +294,7 @@ Example:
     import pytest
 
     from mocket import async_mocketize
-    from mocket.mockhttp import Entry
+    from mocket.mocks.mockhttp import Entry
     from mocket.plugins.aiohttp_connector import MocketTCPConnector
 
 


### PR DESCRIPTION
This pull request updates import paths in the `README.rst` file to reflect a change in the module structure of the `mocket` library. The changes ensure that the examples use the correct imports for the updated library.

Documentation updates:

* Updated import path for `Entry` in the first example to use `mocket.mocks.mockhttp.Entry` instead of `mocket.mockhttp.Entry`. (`README.rst`, [README.rstL104-R104](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL104-R104))
* Updated import path for `Entry` in the second example to use `mocket.mocks.mockhttp.Entry` instead of `mocket.mockhttp.Entry`. (`README.rst`, [README.rstL297-R297](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL297-R297))