### PR TITLE
Match querystring for multiple responses in httpretty plugin

### DIFF
--- a/mocket/plugins/httpretty/__init__.py
+++ b/mocket/plugins/httpretty/__init__.py
@@ -90,7 +90,12 @@ def register_uri(
         Response.set_base_headers = Response.original_set_base_headers  # type: ignore[method-assign]
 
     if responses:
-        Entry.register(method, uri, *responses)
+        Entry.register(
+            method,
+            uri,
+            *responses,
+            match_querystring=match_querystring,
+        )
     else:
         Entry.single_register(
             method,


### PR DESCRIPTION
I'm migrating a large codebase with lots of http mocking from httpretty to python-mocket and making heavy use of your httpretty plugin – many thanks for making this and for actively maintaining python-mocket! ❤️ It is much appreciated!

This PR makes sure match_querystring is passed along properly to ~Entry` when multiple responses are registered using the httpretty plugin.  `match_querystring` is already passed along as expected when a single response is registered, but not currently when multiple responses are registered. 

This change makes a bunch of my tests pass, that otherwise would not