### PR TITLE
tests: add tests for hexdump and hexload, including ValueError on invalid hex

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import NonCallableMock, patch
 
 import decorator
 
-from mocket.utils import get_mocketize
+from mocket.utils import get_mocketize, hexdump, hexload
 
 
 def mock_decorator(func: Callable[[], None]) -> None:
@@ -29,3 +29,27 @@ class GetMocketizeTestCase(TestCase):
         dec.call_args_list[0].assert_compare_to((mock_decorator,), {"kwsyntax": True})
         # Second time without kwsyntax, which succeeds
         dec.call_args_list[1].assert_compare_to((mock_decorator,))
+
+
+class HexdumpTestCase(TestCase):
+    def test_hexdump_converts_bytes_to_spaced_hex(self) -> None:
+        assert hexdump(b"Hi") == "48 69"
+
+    def test_hexdump_empty_bytes(self) -> None:
+        assert hexdump(b"") == ""
+
+    def test_hexdump_roundtrip_with_hexload(self) -> None:
+        data = b"bar foobar foo"
+        assert hexload(hexdump(data)) == data
+
+
+class HexloadTestCase(TestCase):
+    def test_hexload_converts_spaced_hex_to_bytes(self) -> None:
+        assert hexload("48 69") == b"Hi"
+
+    def test_hexload_empty_string(self) -> None:
+        assert hexload("") == b""
+
+    def test_hexload_invalid_hex_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            hexload("ZZ ZZ")


### PR DESCRIPTION
`hexdump` and `hexload` in `mocket/utils.py` both have documented behaviour and even docstring examples, but `test_utils.py` only covers `get_mocketize`. Running the suite with `--no-doctest-modules` leaves those functions at zero coverage, and more importantly the `ValueError` branch in `hexload` - documented under `Raises:` in the docstring - has no test at all, not even via the doctests.

The added `HexdumpTestCase` and `HexloadTestCase` cover the basic conversion, empty-input edge cases, a round-trip assertion, and the missing error path: `hexload("ZZ ZZ")` should raise `ValueError` because `binascii.unhexlify` rejects non-hex characters and `hexload` wraps that as `ValueError`.

Verified by running the relevant tests locally:

```
python -m pytest tests/test_utils.py -v
```