### PR TITLE
mocket/plugins/httpretty: allow to pass exceptions instances to body

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,7 @@ HTTPretty compatibility layer
 Mocket HTTP mock can work as *HTTPretty* replacement for many different use cases. Two main features are missing, or better said, are implemented differently:
 
 - URL entries containing regular expressions, *Mocket* implements `can_handle_fun` which is way simpler to use and more powerful;
-- response body from functions (used mostly to fake errors, *Mocket* accepts an `exception` instead).
+- response body from functions (used mostly to fake errors, *Mocket* accepts an `exception` instead, you can pass an exception instance to body to the compatibility layer).
 
 Both features are documented above.
 

--- a/mocket/plugins/httpretty/__init__.py
+++ b/mocket/plugins/httpretty/__init__.py
@@ -66,7 +66,7 @@ OPTIONS = Entry.OPTIONS
 def register_uri(
     method: str,
     uri: str,
-    body: str = "HTTPretty :)",
+    body: str | Exception = "HTTPretty :)",
     adding_headers: Optional[Dict[str, str]] = None,
     forcing_headers: Optional[Dict[str, str]] = None,
     status: int = 200,
@@ -97,13 +97,20 @@ def register_uri(
             match_querystring=match_querystring,
         )
     else:
+        # permit to pass exception instances as body for users that are passing functions as a body
+        # for testing error handling
+        kwargs = {}
+        if isinstance(body, Exception):
+            kwargs["exception"] = body
+        else:
+            kwargs["body"] = body
         Entry.single_register(
             method,
             uri,
-            body=body,
             status=status,
             headers=headers,
             match_querystring=match_querystring,
+            **kwargs,
         )
 
 

--- a/tests/test_httpretty.py
+++ b/tests/test_httpretty.py
@@ -382,6 +382,6 @@ def test_httpretty_should_mock_body_as_exception():
     )
 
     with pytest.raises(requests.exceptions.ConnectionError):
-        response = requests.get("http://yipit.com")
+        requests.get("http://yipit.com")
     expect(httpretty.last_request.method).to.equal("GET")
     expect(httpretty.last_request.path).to.equal("/")

--- a/tests/test_httpretty.py
+++ b/tests/test_httpretty.py
@@ -23,6 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
+import socket
+
+import pytest
 import requests
 from sure import expect
 
@@ -369,3 +372,16 @@ def test_unicode_querystrings():
     expect(HTTPretty.last_request.querystring["user"][0]).should.be.equal(
         "Gabriel Falcão"
     )
+
+
+@httprettified
+def test_httpretty_should_mock_body_as_exception():
+    """HTTPretty should mock a body as exception"""
+    httpretty.register_uri(
+        httpretty.GET, "http://yipit.com/", body=socket.timeout()
+    )
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        response = requests.get("http://yipit.com")
+    expect(httpretty.last_request.method).to.equal("GET")
+    expect(httpretty.last_request.path).to.equal("/")


### PR DESCRIPTION
While this is a diversion from httpretty API this should let the users that were using functions raising exception to use the compatibility layer.

I'm trying to convert 3 packages test suites away from httpretty and this would be helpful. 